### PR TITLE
[WOOCOU-38] ♻️ ExpirationPolicy 빌더를 정적 팩토리 메서드로 변경

### DIFF
--- a/src/main/java/com/coumin/woowahancoupons/coupon/dto/StoreCouponSaveDto.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/dto/StoreCouponSaveDto.java
@@ -33,10 +33,7 @@ public class StoreCouponSaveDto {
     }
 
     public Coupon toEntity(Long issuerId) {
-        ExpirationPolicy expirationPolicy = ExpirationPolicy.ByAfterIssueDateTypeBuilder()
-            .expirationPolicyType(ExpirationPolicyType.AFTER_ISSUE_DATE)
-            .daysFromIssuance(daysAfterIssuance)
-            .build();
+        ExpirationPolicy expirationPolicy = ExpirationPolicy.newByAfterIssueDate(daysAfterIssuance);
 
         return Coupon.builder(
             name,

--- a/src/main/java/com/coumin/woowahancoupons/domain/coupon/ExpirationPolicy.java
+++ b/src/main/java/com/coumin/woowahancoupons/domain/coupon/ExpirationPolicy.java
@@ -30,28 +30,23 @@ public class ExpirationPolicy {
     @Column(name = "days_from_issuance")
     private Integer daysFromIssuance;
 
-    @Builder(builderClassName = "ByPeriodTypeBuilder", builderMethodName = "ByPeriodTypeBuilder")
-    public ExpirationPolicy(ExpirationPolicyType expirationPolicyType, LocalDateTime startAt,
-        LocalDateTime expiredAt) {
-        Assert.notNull(expirationPolicyType, "expirationPolicyType must not be null");
-        Assert.notNull(startAt, "startAt must not be null");
-        Assert.notNull(expiredAt, "expiredAt must not be null");
-        Assert.isTrue(expirationPolicyType == ExpirationPolicyType.PERIOD, "invalid expirationPolicyType");
-
+    private ExpirationPolicy(
+        ExpirationPolicyType expirationPolicyType, LocalDateTime startAt,
+        LocalDateTime expiredAt, Integer daysFromIssuance) {
         this.expirationPolicyType = expirationPolicyType;
         this.startAt = startAt;
         this.expiredAt = expiredAt;
+        this.daysFromIssuance = daysFromIssuance;
     }
 
-    @Builder(builderClassName = "ByAfterIssueDateTypeBuilder", builderMethodName = "ByAfterIssueDateTypeBuilder")
-    public ExpirationPolicy(
-        ExpirationPolicyType expirationPolicyType,
-        Integer daysFromIssuance) {
-        Assert.notNull(expirationPolicyType, "expirationPolicyType must not be null");
+    public static ExpirationPolicy newByAfterIssueDate(Integer daysFromIssuance) {
         Assert.notNull(daysFromIssuance, "daysFromIssuance must not be null");
-        Assert.isTrue(expirationPolicyType == ExpirationPolicyType.AFTER_ISSUE_DATE, "invalid expirationPolicyType");
+        return new ExpirationPolicy(ExpirationPolicyType.AFTER_ISSUE_DATE, null, null, daysFromIssuance);
+    }
 
-        this.expirationPolicyType = expirationPolicyType;
-        this.daysFromIssuance = daysFromIssuance;
+    public static ExpirationPolicy newByPeriod(LocalDateTime startAt, LocalDateTime expiredAt) {
+        Assert.notNull(startAt, "startAt must not be null");
+        Assert.notNull(expiredAt, "expiredAt must not be null");
+        return new ExpirationPolicy(ExpirationPolicyType.PERIOD, startAt, expiredAt, null);
     }
 }

--- a/src/test/java/com/coumin/woowahancoupons/domain/ExpirationPolicyTest.java
+++ b/src/test/java/com/coumin/woowahancoupons/domain/ExpirationPolicyTest.java
@@ -20,11 +20,7 @@ class ExpirationPolicyTest {
         ExpirationPolicyType expirationPolicyType = ExpirationPolicyType.PERIOD;
 
         //When
-        ExpirationPolicy expirationPolicy = ExpirationPolicy.ByPeriodTypeBuilder()
-            .expirationPolicyType(expirationPolicyType)
-            .startAt(startAt)
-            .expiredAt(expiredAt)
-            .build();
+        ExpirationPolicy expirationPolicy = ExpirationPolicy.newByPeriod(startAt, expiredAt);
 
         //Then
         SoftAssertions.assertSoftly(softAssertions -> {
@@ -45,31 +41,11 @@ class ExpirationPolicyTest {
 
         //When, Then
         assertThatIllegalArgumentException().isThrownBy(() -> {
-            ExpirationPolicy.ByPeriodTypeBuilder()
-                .expiredAt(startAt)
-                .build();
-        }).withMessage("expirationPolicyType must not be null");
-
-        assertThatIllegalArgumentException().isThrownBy(() -> {
-            ExpirationPolicy.ByPeriodTypeBuilder()
-                .expirationPolicyType(ExpirationPolicyType.AFTER_ISSUE_DATE)
-                .startAt(startAt)
-                .expiredAt(expiredAt)
-                .build();
-        }).withMessage("invalid expirationPolicyType");
-
-        assertThatIllegalArgumentException().isThrownBy(() -> {
-            ExpirationPolicy.ByPeriodTypeBuilder()
-                .expirationPolicyType(ExpirationPolicyType.PERIOD)
-                .expiredAt(expiredAt)
-                .build();
+            ExpirationPolicy.newByPeriod(null, expiredAt);
         }).withMessage("startAt must not be null");
 
         assertThatIllegalArgumentException().isThrownBy(() -> {
-            ExpirationPolicy.ByPeriodTypeBuilder()
-                .expirationPolicyType(ExpirationPolicyType.PERIOD)
-                .startAt(startAt)
-                .build();
+            ExpirationPolicy.newByPeriod(startAt, null);
         }).withMessage("expiredAt must not be null");
     }
 
@@ -81,15 +57,11 @@ class ExpirationPolicyTest {
         int days = 7;
 
         //When
-        ExpirationPolicy expirationPolicy = ExpirationPolicy.ByAfterIssueDateTypeBuilder()
-            .expirationPolicyType(expirationPolicyType)
-            .daysFromIssuance(days)
-            .build();
+        ExpirationPolicy expirationPolicy = ExpirationPolicy.newByAfterIssueDate(days);
 
         //Then
         SoftAssertions.assertSoftly(softAssertions -> {
-                softAssertions.assertThat(expirationPolicy.getExpirationPolicyType())
-                    .isEqualTo(expirationPolicyType);
+                softAssertions.assertThat(expirationPolicy.getExpirationPolicyType()).isEqualTo(expirationPolicyType);
                 softAssertions.assertThat(expirationPolicy.getDaysFromIssuance()).isEqualTo(days);
             }
         );
@@ -98,27 +70,8 @@ class ExpirationPolicyTest {
     @Test
     @DisplayName("조건에 맞지 않는 경우, 실제 쿠폰 발급일시를 기준으로 지정된 기간을 쿠폰의 유효기간으로 하는 만료 정책 객체 생성 실패")
     void byAfterIssueDateTypeBuilderFailTest() {
-        //Given
-        int days = 7;
-
-        //When, Then
         assertThatIllegalArgumentException().isThrownBy(() -> {
-            ExpirationPolicy.ByAfterIssueDateTypeBuilder()
-                .daysFromIssuance(days)
-                .build();
-        }).withMessage("expirationPolicyType must not be null");
-
-        assertThatIllegalArgumentException().isThrownBy(() -> {
-            ExpirationPolicy.ByAfterIssueDateTypeBuilder()
-                .expirationPolicyType(ExpirationPolicyType.PERIOD)
-                .daysFromIssuance(days)
-                .build();
-        }).withMessage("invalid expirationPolicyType");
-
-        assertThatIllegalArgumentException().isThrownBy(() -> {
-            ExpirationPolicy.ByAfterIssueDateTypeBuilder()
-                .expirationPolicyType(ExpirationPolicyType.AFTER_ISSUE_DATE)
-                .build();
+            ExpirationPolicy.newByAfterIssueDate(null);
         }).withMessage("daysFromIssuance must not be null");
     }
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
[WOOCOU-38](https://maenguin.atlassian.net/browse/WOOCOU-38)

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
* ExpirationPolicy 클래스의 빌더를 정적 팩토리 메서드로 변경해 보았습니다.
1. ExpirationPolicy 클래스에 ByPeriodTypeBuilder와 ByAfterIssueDateTypeBuilder가 있는데 해당 빌더들을 사용해서 객체를 생성할 때 필수 값을 누락할 수 있는 여지가 있습니다. (validation이 있지만 까먹고 필수 값을 넣거나 필수값이 아닌걸 넣을 수도 있겠다는 생각이 들었습니다.)
2. 빌더를 사용하는 목적이 필드의 개수가 많을 때 필수 값이 아닌 필드를 클라이언트가 유연하게 설정할 수 있는데 있다고 생각했습니다. 현재 코드는 유효기간 정책마다 필수 값을 받고 있기 때문에 빌더가 아니라 생성자를 쓰는 게 맞다고 판단했습니다. (필드 갯수도 적구요)
3. 그리고 유효기간 정책별로 다르게 객체를 구성해야 되기 때문에 정적 팩토리 메서드를 만들었습니다.
(expirationPolicyType은 정책 별로 구분이 되기 때문에 자동으로 set하게 했습니다.)
