### PR TITLE
[WOOCOU-44] ⭐ feat : 매장의 쿠폰 리스트 조회 서비스 추가

### DIFF
--- a/src/main/java/com/coumin/woowahancoupons/coupon/dto/StoreCouponResponseDto.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/dto/StoreCouponResponseDto.java
@@ -1,0 +1,30 @@
+package com.coumin.woowahancoupons.coupon.dto;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import com.coumin.woowahancoupons.domain.coupon.Coupon;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StoreCouponResponseDto {
+
+    private long id;
+
+    private String name;
+
+    private long amount;
+
+    private int daysAfterIssuance;
+
+    private Long minOrderPrice;
+
+    public StoreCouponResponseDto(Coupon coupon) {
+        this.id = coupon.getId();
+        this.name = coupon.getName();
+        this.amount = coupon.getAmount();
+        this.daysAfterIssuance = coupon.getExpirationPolicy().getDaysFromIssuance();
+        this.minOrderPrice = coupon.getMinOrderPrice();
+    }
+}

--- a/src/main/java/com/coumin/woowahancoupons/domain/coupon/Coupon.java
+++ b/src/main/java/com/coumin/woowahancoupons/domain/coupon/Coupon.java
@@ -7,7 +7,7 @@ import java.util.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "coupons")
+@Table(name = "coupons", indexes = @Index(name = "coupon_idx", columnList = "issuer_id"))
 @Entity
 public class Coupon extends BaseEntity {
 
@@ -16,10 +16,10 @@ public class Coupon extends BaseEntity {
     @Column(name = "coupon_id")
     private Long id;
 
-    @Column(nullable = false, length = 100)
+    @Column(name = "name", nullable = false, length = 100)
     private String name;
 
-    @Column(nullable = false)
+    @Column(name = "amount", nullable = false)
     private Long amount;
 
     @Embedded
@@ -29,14 +29,14 @@ public class Coupon extends BaseEntity {
     private Long minOrderPrice;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 30)
+    @Column(name = "discount_type", nullable = false, length = 30)
     private DiscountType discountType;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 30)
+    @Column(name = "issuer_type", nullable = false, length = 30)
     private IssuerType issuerType;
 
-    @Column(nullable = false)
+    @Column(name = "issuer_id", nullable = false)
     private Long issuerId;
 
     @Column(name = "max_cnt")

--- a/src/main/java/com/coumin/woowahancoupons/store/service/SimpleStoreService.java
+++ b/src/main/java/com/coumin/woowahancoupons/store/service/SimpleStoreService.java
@@ -1,8 +1,27 @@
 package com.coumin.woowahancoupons.store.service;
 
+import com.coumin.woowahancoupons.domain.coupon.CouponRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
+import com.coumin.woowahancoupons.coupon.dto.StoreCouponResponseDto;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 @Service
 public class SimpleStoreService implements StoreService {
 
+	private final CouponRepository couponRepository;
+
+	public SimpleStoreService(
+		CouponRepository couponRepository) {
+		this.couponRepository = couponRepository;
+	}
+
+	@Override
+	public List<StoreCouponResponseDto> findStoreCoupons(Long storeId) {
+		return couponRepository.findByIssuerId(storeId).stream()
+			.map(StoreCouponResponseDto::new)
+			.collect(Collectors.toList());
+	}
 }

--- a/src/main/java/com/coumin/woowahancoupons/store/service/StoreService.java
+++ b/src/main/java/com/coumin/woowahancoupons/store/service/StoreService.java
@@ -1,5 +1,9 @@
 package com.coumin.woowahancoupons.store.service;
 
+import java.util.List;
+import com.coumin.woowahancoupons.coupon.dto.StoreCouponResponseDto;
+
 public interface StoreService {
 
+	List<StoreCouponResponseDto> findStoreCoupons(Long storeId);
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
[WOOCOU-44](https://maenguin.atlassian.net/browse/WOOCOU-44)

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
Coupon 엔티티의 issuerId에 index 걸었습니다.
- 현재 기획상 해당 컬럼의 update, delete가 거의 일어나지 않다는 점
- 현재 기획상 매장 쿠폰을 가져올 경우 where절에 issuerId를 사용한다는 점
- 현재 기획상 issuerId로  조건을 걸어 쿠폰을 조회하는 경우는 매장 쿠폰 조회할 경우뿐이라, 인덱스 사용시 해당 issuerId의 값의 분포도가 낮을거라고 예상했습니다!