### PR TITLE
[WOOCOU-40] ⭐ feat : 쿠폰번호를 입력해 쿠폰 등록 기능 컨트롤러단 구현

### DIFF
--- a/src/main/java/com/coumin/woowahancoupons/coupon/controller/CouponRedemptionRestController.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/controller/CouponRedemptionRestController.java
@@ -1,8 +1,29 @@
 package com.coumin.woowahancoupons.coupon.controller;
 
+import com.coumin.woowahancoupons.coupon.service.CouponRedemptionService;
+import com.coumin.woowahancoupons.global.ApiResponse;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequestMapping("api/v1/coupons")
 @RestController
 public class CouponRedemptionRestController {
 
+    private final CouponRedemptionService couponRedemptionService;
+
+    public CouponRedemptionRestController(
+        CouponRedemptionService couponRedemptionService) {
+        this.couponRedemptionService = couponRedemptionService;
+    }
+
+    @PatchMapping("/{couponCode}/customers/{customerId}/register")
+    public ApiResponse<Object> registerCouponCode(
+        @PathVariable("couponCode") UUID couponCode,
+        @PathVariable("customerId") Long customerId) {
+        couponRedemptionService.allocateExistingCouponToCustomer(couponCode, customerId);
+        return ApiResponse.success();
+    }
 }

--- a/src/main/java/com/coumin/woowahancoupons/coupon/service/CouponRedemptionService.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/service/CouponRedemptionService.java
@@ -3,5 +3,5 @@ package com.coumin.woowahancoupons.coupon.service;
 import java.util.UUID;
 
 public interface CouponRedemptionService {
-    void allocateCouponToCustomer(UUID couponId, Long customerId);
+    void allocateExistingCouponToCustomer(UUID couponCode, Long customerId);
 }

--- a/src/main/java/com/coumin/woowahancoupons/coupon/service/SimpleCouponRedemptionService.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/service/SimpleCouponRedemptionService.java
@@ -25,9 +25,9 @@ public class SimpleCouponRedemptionService implements CouponRedemptionService {
 
     @Transactional
     @Override
-    public void allocateCouponToCustomer(UUID couponId, Long customerId) {
-        CouponRedemption couponRedemption = couponRedemptionRepository.findById(couponId)
-            .orElseThrow(() -> new CouponRedemptionNotFoundException(couponId));
+    public void allocateExistingCouponToCustomer(UUID couponCode, Long customerId) {
+        CouponRedemption couponRedemption = couponRedemptionRepository.findById(couponCode)
+            .orElseThrow(() -> new CouponRedemptionNotFoundException(couponCode));
         Customer customer = customerRepository.getById(customerId);
         couponRedemption.changeCustomer(customer);
     }

--- a/src/main/java/com/coumin/woowahancoupons/domain/coupon/CouponRedemption.java
+++ b/src/main/java/com/coumin/woowahancoupons/domain/coupon/CouponRedemption.java
@@ -55,7 +55,7 @@ public class CouponRedemption {
         return new CouponRedemption(coupon, null);
     }
 
-    public static CouponRedemption from(Coupon coupon, Customer customer) {
+    public static CouponRedemption of(Coupon coupon, Customer customer) {
         Assert.notNull(customer, "customer must be not null");
         return new CouponRedemption(coupon, customer);
     }

--- a/src/main/java/com/coumin/woowahancoupons/domain/coupon/CouponRedemption.java
+++ b/src/main/java/com/coumin/woowahancoupons/domain/coupon/CouponRedemption.java
@@ -6,6 +6,7 @@ import lombok.*;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import org.springframework.util.Assert;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -39,11 +40,23 @@ public class CouponRedemption {
     @JoinColumn(name = "customer_id")
     private Customer customer;
 
-    public CouponRedemption(Coupon coupon) {
+    private CouponRedemption(Coupon coupon, Customer customer) {
+        Assert.notNull(coupon, "coupon must be not null");
         this.coupon = coupon;
+        this.customer = customer;
+        this.expirationPeriod = coupon.getExpirationPolicy().newExpirationPeriod();
     }
 
     public void changeCustomer(Customer customer) {
         this.customer = customer;
+    }
+
+    public static CouponRedemption of(Coupon coupon) {
+        return new CouponRedemption(coupon, null);
+    }
+
+    public static CouponRedemption from(Coupon coupon, Customer customer) {
+        Assert.notNull(customer, "customer must be not null");
+        return new CouponRedemption(coupon, customer);
     }
 }

--- a/src/main/java/com/coumin/woowahancoupons/domain/coupon/ExpirationPolicy.java
+++ b/src/main/java/com/coumin/woowahancoupons/domain/coupon/ExpirationPolicy.java
@@ -6,7 +6,6 @@ import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.Assert;
@@ -48,5 +47,15 @@ public class ExpirationPolicy {
         Assert.notNull(startAt, "startAt must not be null");
         Assert.notNull(expiredAt, "expiredAt must not be null");
         return new ExpirationPolicy(ExpirationPolicyType.PERIOD, startAt, expiredAt, null);
+    }
+
+    public ExpirationPeriod newExpirationPeriod() {
+        LocalDateTime startAt = this.startAt;
+        LocalDateTime expiredAt = this.expiredAt;
+        if (this.expirationPolicyType == ExpirationPolicyType.AFTER_ISSUE_DATE) {
+            startAt = LocalDateTime.now();
+            expiredAt = LocalDateTime.now().plusDays(this.daysFromIssuance);
+        }
+        return new ExpirationPeriod(startAt, expiredAt);
     }
 }

--- a/src/test/java/com/coumin/woowahancoupons/coupon/TestCouponFactory.java
+++ b/src/test/java/com/coumin/woowahancoupons/coupon/TestCouponFactory.java
@@ -1,0 +1,19 @@
+package com.coumin.woowahancoupons.coupon;
+
+import com.coumin.woowahancoupons.domain.coupon.Coupon;
+import com.coumin.woowahancoupons.domain.coupon.DiscountType;
+import com.coumin.woowahancoupons.domain.coupon.ExpirationPolicy;
+import com.coumin.woowahancoupons.domain.coupon.IssuerType;
+import java.time.LocalDateTime;
+
+public class TestCouponFactory {
+
+    public static Coupon.CouponBuilder builder() {
+        return Coupon.builder("test coupon",
+                1000L,
+                ExpirationPolicy.newByPeriod(LocalDateTime.now(), LocalDateTime.now().plusDays(30)),
+                DiscountType.FIXED_AMOUNT,
+                IssuerType.ADMIN,
+                1L);
+    }
+}

--- a/src/test/java/com/coumin/woowahancoupons/coupon/TestCouponFactory.java
+++ b/src/test/java/com/coumin/woowahancoupons/coupon/TestCouponFactory.java
@@ -9,7 +9,8 @@ import java.time.LocalDateTime;
 public class TestCouponFactory {
 
     public static Coupon.CouponBuilder builder() {
-        return Coupon.builder("test coupon",
+        return Coupon.builder(
+                "test coupon",
                 1000L,
                 ExpirationPolicy.newByPeriod(LocalDateTime.now(), LocalDateTime.now().plusDays(30)),
                 DiscountType.FIXED_AMOUNT,

--- a/src/test/java/com/coumin/woowahancoupons/coupon/controller/CouponRedemptionRestControllerTest.java
+++ b/src/test/java/com/coumin/woowahancoupons/coupon/controller/CouponRedemptionRestControllerTest.java
@@ -1,0 +1,97 @@
+package com.coumin.woowahancoupons.coupon.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.coumin.woowahancoupons.coupon.TestCouponFactory;
+import com.coumin.woowahancoupons.domain.coupon.Coupon;
+import com.coumin.woowahancoupons.domain.coupon.CouponRedemption;
+import com.coumin.woowahancoupons.domain.customer.Customer;
+import com.coumin.woowahancoupons.global.error.ErrorCode;
+import java.util.UUID;
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+class CouponRedemptionRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    EntityManager entityManager;
+
+    private Customer testCustomer;
+
+    private Coupon testCoupon;
+
+    @BeforeEach
+    public void beforeEach() {
+        testCustomer = new Customer("test@gmail.com");
+        testCoupon = TestCouponFactory.builder().build();
+        entityManager.persist(testCustomer);
+        entityManager.persist(testCoupon);
+    }
+
+    @Test
+    @DisplayName("고객이 쿠폰 번호를 입력해 쿠폰 등록 - 성공 테스트")
+    void registerCouponCodeSuccessTest() throws Exception {
+        //given
+        CouponRedemption couponRedemption = CouponRedemption.of(testCoupon);
+        entityManager.persist(couponRedemption);
+        //when
+        ResultActions result = mockMvc.perform(
+            patch("/api/v1/coupons/{couponCode}/customers/{customerId}/register",
+                couponRedemption.getId(),
+                testCustomer.getId())
+                .accept(MediaType.APPLICATION_JSON)
+        );
+        //then
+        result.andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(handler().handlerType(CouponRedemptionRestController.class))
+            .andExpect(handler().methodName("registerCouponCode"))
+            .andExpect(jsonPath("$.success", is(true)))
+            .andExpect(jsonPath("$.error", is(nullValue())));
+    }
+
+    @Test
+    @DisplayName("고객이 쿠폰 번호를 입력해 쿠폰 등록 - 실패 테스트 (잘못된 쿠폰 번호)")
+    void registerCouponCodeFailureTest() throws Exception {
+        //given
+        UUID wrongCouponCode = UUID.randomUUID();
+        //when
+        ResultActions result = mockMvc.perform(
+            patch("/api/v1/coupons/{couponCode}/customers/{customerId}/register",
+                wrongCouponCode,
+                testCustomer.getId())
+                .accept(MediaType.APPLICATION_JSON)
+        );
+        //then
+        result.andDo(print())
+            .andExpect(status().is4xxClientError())
+            .andExpect(handler().handlerType(CouponRedemptionRestController.class))
+            .andExpect(handler().methodName("registerCouponCode"))
+            .andExpect(jsonPath("$.success", is(false)))
+            .andExpect(jsonPath("$.data", is(nullValue())))
+            .andExpect(jsonPath("$.error.code", is(ErrorCode.COUPON_REDEMPTION_NOT_FOUND.getCode())))
+            .andExpect(jsonPath("$.error.message", containsString(ErrorCode.COUPON_REDEMPTION_NOT_FOUND.getMessage())));
+    }
+}

--- a/src/test/java/com/coumin/woowahancoupons/coupon/service/SimpleCouponRedemptionServiceTest.java
+++ b/src/test/java/com/coumin/woowahancoupons/coupon/service/SimpleCouponRedemptionServiceTest.java
@@ -39,14 +39,14 @@ class SimpleCouponRedemptionServiceTest {
     void allocateCouponToCustomerSuccessTest() {
         //Given
         Long customerId = 1L;
-        CouponRedemption couponRedemption = new CouponRedemption(mock(Coupon.class));
+        CouponRedemption couponRedemption = CouponRedemption.of(mock(Coupon.class));
         Customer mockCustomer = mock(Customer.class);
         given(couponRedemptionRepository.findById(any())).willReturn(Optional.of(couponRedemption));
         given(customerRepository.getById(customerId)).willReturn(mockCustomer);
         given(mockCustomer.getId()).willReturn(customerId);
         //When
         assertThat(couponRedemption.getCustomer()).isNull();
-        couponRedemptionService.allocateCouponToCustomer(UUID.randomUUID(), customerId);
+        couponRedemptionService.allocateExistingCouponToCustomer(UUID.randomUUID(), customerId);
         //Then
         assertThat(couponRedemption.getCustomer()).isNotNull();
         assertThat(couponRedemption.getCustomer().getId()).isEqualTo(customerId);
@@ -58,7 +58,7 @@ class SimpleCouponRedemptionServiceTest {
         //Given
         given(couponRedemptionRepository.findById(any())).willReturn(Optional.empty());
         //When Then
-        assertThatThrownBy(() -> couponRedemptionService.allocateCouponToCustomer(UUID.randomUUID(), 1L))
+        assertThatThrownBy(() -> couponRedemptionService.allocateExistingCouponToCustomer(UUID.randomUUID(), 1L))
             .isInstanceOf(CouponRedemptionNotFoundException.class)
             .hasMessageContaining(ErrorCode.COUPON_REDEMPTION_NOT_FOUND.getMessage());
     }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
[WOOCOU-40](https://maenguin.atlassian.net/browse/WOOCOU-40)

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
[⭐ feat : ExpirationPolicy가 ExpirationPeriod를 생성할 수 있도록 메서드 추가](https://github.com/prgrms-be-devcourse/BEDV1_Woowahan-Coupons/commit/c71d62d950d3fd3781b18a7ceba379ac085371ef)
* 기획상 ExpirationPeriod를 생성할때 ExpirationPolicy정보에 의존하기 때문에 ExpirationPolicy에서 ExpirationPeriod를 생성하는 메서드를 만들었습니다. 
* 반대로 ExpirationPeriod에서 ExpirationPolicy를 받아서 생성할까 생각했는데 전자가 좀 더 ExpirationPeriod를 유연하게 가져갈 수 있을것 같아서 전자를 선택했습니다.

[♻️ refactor : allocateCouponToCustomer -> allocateExistingCouponToCustomer으로 이름 변경](https://github.com/prgrms-be-devcourse/BEDV1_Woowahan-Coupons/commit/00ddf734f80c9794548eb1f17a6a64244fcabcb2)
* 나중에 구현하게될 버튼 쿠폰을 통한 쿠폰발급과 구별을 하기 위해 좀 더 명확한 네이밍으로 메서드 이름을 변경했습니다.

[⭐ feat : 쿠폰번호를 입력해 쿠폰 등록 기능 컨트롤러단 구현](https://github.com/prgrms-be-devcourse/BEDV1_Woowahan-Coupons/commit/498b93ddc17789cbff76b66f0dd02146b019ceea)
* 해당 기능에 대한 컨트롤러와 테스트를 추가했습니다.
* 컨트롤러 메서드 이름을 registerCouponCode라고 했는데 Service 레이어 까지는 백엔드 개발자의 입장의 네이밍을 선택했고 Contoller 레이어에서는 프론트 개발자 입장의 네이밍을 지으면 좋을 것 같아서 그렇게 정했습니다. (이름 짓는거랑 API 경로 이름 짓는거 너무 어렵네요 피드백 부탁드립니다 ㅠㅠ)
* Coupon 엔티티가 필드가 많기 때문에 테스트 전용으로 사용할 `TestCouponFactory`를 만들어보았습니다.

