### PR TITLE
[WOOCOU-62] ⭐ feat : 유저의 쿠폰 조회를 위한 reopository 및 도메인 로직 추가

### DIFF
--- a/src/main/java/com/coumin/woowahancoupons/domain/coupon/CouponRedemption.java
+++ b/src/main/java/com/coumin/woowahancoupons/domain/coupon/CouponRedemption.java
@@ -3,11 +3,14 @@ package com.coumin.woowahancoupons.domain.coupon;
 import com.coumin.woowahancoupons.domain.BaseEntity;
 import com.coumin.woowahancoupons.domain.customer.Customer;
 import com.coumin.woowahancoupons.domain.Order;
+import com.coumin.woowahancoupons.global.exception.CouponAlreadyUseException;
+import com.coumin.woowahancoupons.global.exception.CouponExpireException;
 import com.coumin.woowahancoupons.global.exception.CouponRedemptionAlreadyAllocateCustomer;
 import lombok.*;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.util.Assert;
 
 @Getter
@@ -69,9 +72,28 @@ public class CouponRedemption extends BaseEntity {
         this.customer = customer;
     }
 
+    public void use() {
+        verifyExpiration();
+        verifyUsed();
+        this.used = true;
+        this.usedAt = LocalDateTime.now();
+    }
+
     public void verifyCustomer() {
         if (customer != null) {
             throw new CouponRedemptionAlreadyAllocateCustomer();
+        }
+    }
+
+    private void verifyExpiration() {
+        if (expirationPeriod.isExpiration()) {
+            throw new CouponExpireException();
+        }
+    }
+
+    private void verifyUsed() {
+        if (used) {
+            throw new CouponAlreadyUseException();
         }
     }
 }

--- a/src/main/java/com/coumin/woowahancoupons/domain/coupon/CouponRedemptionRepository.java
+++ b/src/main/java/com/coumin/woowahancoupons/domain/coupon/CouponRedemptionRepository.java
@@ -1,10 +1,16 @@
 package com.coumin.woowahancoupons.domain.coupon;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CouponRedemptionRepository extends JpaRepository<CouponRedemption, UUID> {
 
     Optional<CouponRedemption> findByCouponCode(UUID couponCode);
+
+    @EntityGraph(attributePaths = {"coupon"}, type = EntityGraphType.LOAD)
+    List<CouponRedemption> findByCustomerIdAndUsedFalse(Long customerId);
 }

--- a/src/main/java/com/coumin/woowahancoupons/domain/coupon/ExpirationPeriod.java
+++ b/src/main/java/com/coumin/woowahancoupons/domain/coupon/ExpirationPeriod.java
@@ -20,4 +20,8 @@ public class ExpirationPeriod {
         this.startAt = startAt;
         this.expiredAt = expiredAt;
     }
+
+    public boolean isExpiration() {
+        return LocalDateTime.now().isAfter(expiredAt);
+    }
 }

--- a/src/main/java/com/coumin/woowahancoupons/global/error/ErrorCode.java
+++ b/src/main/java/com/coumin/woowahancoupons/global/error/ErrorCode.java
@@ -16,7 +16,9 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(400, "C004", "Invalid Input Value"),
     METHOD_NOT_ALLOWED(405, "C005", "Method not allowed"),
 
-    COUPON_REDEMPTION_ALREADY_ALLOCATE(400, "CO06", "Already allocated for customer");
+    COUPON_REDEMPTION_ALREADY_ALLOCATE(400, "CO06", "CouponRedemption was already allocated"),
+    COUPON_REDEMPTION_ALREADY_USE(400, "CO07", "CouponRedemption was already used"),
+    COUPON_REDEMPTION_EXPIRE(400, "CO08", "CouponRedemption was already expired");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/coumin/woowahancoupons/global/exception/CouponAlreadyUseException.java
+++ b/src/main/java/com/coumin/woowahancoupons/global/exception/CouponAlreadyUseException.java
@@ -1,0 +1,10 @@
+package com.coumin.woowahancoupons.global.exception;
+
+import com.coumin.woowahancoupons.global.error.ErrorCode;
+
+public class CouponAlreadyUseException extends BusinessException {
+
+    public CouponAlreadyUseException() {
+        super(ErrorCode.COUPON_REDEMPTION_ALREADY_USE);
+    }
+}

--- a/src/main/java/com/coumin/woowahancoupons/global/exception/CouponExpireException.java
+++ b/src/main/java/com/coumin/woowahancoupons/global/exception/CouponExpireException.java
@@ -1,0 +1,10 @@
+package com.coumin.woowahancoupons.global.exception;
+
+import com.coumin.woowahancoupons.global.error.ErrorCode;
+
+public class CouponExpireException extends BusinessException {
+
+    public CouponExpireException() {
+        super(ErrorCode.COUPON_REDEMPTION_EXPIRE);
+    }
+}

--- a/src/test/java/com/coumin/woowahancoupons/domain/coupon/CouponRedemptionRepositoryTest.java
+++ b/src/test/java/com/coumin/woowahancoupons/domain/coupon/CouponRedemptionRepositoryTest.java
@@ -2,7 +2,9 @@ package com.coumin.woowahancoupons.domain.coupon;
 
 
 import com.coumin.woowahancoupons.coupon.TestCouponFactory;
+import com.coumin.woowahancoupons.domain.customer.Customer;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -58,6 +60,42 @@ class CouponRedemptionRepositoryTest {
         SoftAssertions.assertSoftly(softAssertions -> {
                 softAssertions.assertThat(foundCouponRedemption.getId())
                     .isEqualTo(couponRedemption.getId());
+            }
+        );
+    }
+
+    @Test
+    @DisplayName("고객으로 아직 사용하지 않은 쿠폰리뎀션 리스트 조회")
+    void findByCustomerAndUsedNotTest() {
+        //Given
+        Coupon coupon = TestCouponFactory.builder().build();
+        entityManager.persist(coupon);
+        Customer customer = new Customer("tester");
+        entityManager.persist(customer);
+
+        CouponRedemption couponRedemption1 = CouponRedemption.of(coupon, customer);
+        entityManager.persist(couponRedemption1);
+        CouponRedemption couponRedemption2 = CouponRedemption.of(coupon, customer);
+        entityManager.persist(couponRedemption2);
+        CouponRedemption couponRedemption3 = CouponRedemption.of(coupon, customer);
+        couponRedemption3.use();
+        entityManager.persist(couponRedemption3);
+        entityManager.clear();
+
+        //When
+        List<CouponRedemption> foundCouponRedemption = couponRedemptionRepository
+            .findByCustomerIdAndUsedFalse(customer.getId());
+        foundCouponRedemption.get(0).getCoupon().getMinOrderPrice(); // n+1 check
+
+        //Then
+        SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(foundCouponRedemption)
+                    .isNotEmpty()
+                    .hasSize(2);
+                foundCouponRedemption.forEach(couponRedemption -> {
+                        softAssertions.assertThat(couponRedemption.isUsed()).isEqualTo(false);
+                    }
+                );
             }
         );
     }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
[WOOCOU-62](https://maenguin.atlassian.net/browse/WOOCOU-62)

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
validation 로직을 안하기로 했지만 use의 경우 간단하고 테스트 코드 작성하면서 겸사겸사 구현했습니다.
- 한번 봐주세요 😢 
  -  고객 아이디로 사용안한 쿠폰 리뎀션을 조회하는 repo 메소드 추가했습니다.

- 쿠폰 페치를 위해 엔티티 그래프 애노테이션 추가했습니다. 