### PR TITLE
[WOOCOU-74] ⭐ feat : 사용자의 쿠폰 사용 서비스 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    // https://mvnrepository.com/artifact/org.mockito/mockito-inline
+    testImplementation 'org.mockito:mockito-inline:3.8.0'
 }
 
 test {

--- a/src/main/java/com/coumin/woowahancoupons/coupon/service/CouponRedemptionService.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/service/CouponRedemptionService.java
@@ -13,4 +13,6 @@ public interface CouponRedemptionService {
     List<CouponRedemptionResponseDto> findCustomerCouponRedemptions(Long customerId);
 
     void issueCouponCodes(Long couponId, int issuanceCount);
+
+    void useCustomerCoupon(Long couponRedemptionId);
 }

--- a/src/main/java/com/coumin/woowahancoupons/coupon/service/SimpleCouponRedemptionService.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/service/SimpleCouponRedemptionService.java
@@ -75,12 +75,21 @@ public class SimpleCouponRedemptionService implements CouponRedemptionService {
         Coupon coupon = couponRepository.findByIdForUpdate(couponId)
             .orElseThrow(() -> new CouponNotFoundException(couponId));
         if (!coupon.canIssueCouponCodes(issuanceCount)) {
-            throw new CouponMaxCountOverException(coupon.getMaxCount(), coupon.getAllocatedCount(), issuanceCount);
+            throw new CouponMaxCountOverException(coupon.getMaxCount(), coupon.getAllocatedCount(),
+                issuanceCount);
         }
         List<CouponRedemption> couponRedemptions = IntStream.rangeClosed(1, issuanceCount)
             .mapToObj(operand -> CouponRedemption.of(coupon))
             .collect(Collectors.toList());
         int insertSize = couponRedemptionRepository.saveAll(couponRedemptions).size();
         coupon.increaseAllocatedCount(insertSize);
+    }
+
+    @Transactional
+    @Override
+    public void useCustomerCoupon(Long couponRedemptionId) {
+        CouponRedemption couponRedemption = couponRedemptionRepository.findById(couponRedemptionId)
+            .orElseThrow(() -> new CouponRedemptionNotFoundException(couponRedemptionId));
+        couponRedemption.use();
     }
 }

--- a/src/main/java/com/coumin/woowahancoupons/domain/coupon/CouponRedemption.java
+++ b/src/main/java/com/coumin/woowahancoupons/domain/coupon/CouponRedemption.java
@@ -4,13 +4,12 @@ import com.coumin.woowahancoupons.domain.BaseEntity;
 import com.coumin.woowahancoupons.domain.customer.Customer;
 import com.coumin.woowahancoupons.domain.Order;
 import com.coumin.woowahancoupons.global.exception.CouponAlreadyUseException;
-import com.coumin.woowahancoupons.global.exception.CouponExpireException;
+import com.coumin.woowahancoupons.global.exception.CouponRedemptionExpireException;
 import com.coumin.woowahancoupons.global.exception.CouponRedemptionAlreadyAllocateCustomer;
 import lombok.*;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.util.Assert;
 
 @Getter
@@ -79,7 +78,7 @@ public class CouponRedemption extends BaseEntity {
         this.usedAt = LocalDateTime.now();
     }
 
-    public void verifyCustomer() {
+    private void verifyCustomer() {
         if (customer != null) {
             throw new CouponRedemptionAlreadyAllocateCustomer();
         }
@@ -87,7 +86,7 @@ public class CouponRedemption extends BaseEntity {
 
     private void verifyExpiration() {
         if (expirationPeriod.isExpiration()) {
-            throw new CouponExpireException();
+            throw new CouponRedemptionExpireException();
         }
     }
 

--- a/src/main/java/com/coumin/woowahancoupons/domain/coupon/CouponRedemptionRepository.java
+++ b/src/main/java/com/coumin/woowahancoupons/domain/coupon/CouponRedemptionRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CouponRedemptionRepository extends JpaRepository<CouponRedemption, UUID> {
+public interface CouponRedemptionRepository extends JpaRepository<CouponRedemption, Long> {
 
     Optional<CouponRedemption> findByCouponCode(UUID couponCode);
 

--- a/src/main/java/com/coumin/woowahancoupons/global/exception/CouponRedemptionExpireException.java
+++ b/src/main/java/com/coumin/woowahancoupons/global/exception/CouponRedemptionExpireException.java
@@ -2,9 +2,9 @@ package com.coumin.woowahancoupons.global.exception;
 
 import com.coumin.woowahancoupons.global.error.ErrorCode;
 
-public class CouponExpireException extends BusinessException {
+public class CouponRedemptionExpireException extends BusinessException {
 
-    public CouponExpireException() {
+    public CouponRedemptionExpireException() {
         super(ErrorCode.COUPON_REDEMPTION_EXPIRE);
     }
 }

--- a/src/main/java/com/coumin/woowahancoupons/global/exception/CouponRedemptionNotFoundException.java
+++ b/src/main/java/com/coumin/woowahancoupons/global/exception/CouponRedemptionNotFoundException.java
@@ -5,7 +5,11 @@ import java.util.UUID;
 
 public class CouponRedemptionNotFoundException extends EntityNotFoundException {
 
-    public CouponRedemptionNotFoundException(UUID targetId) {
+    public CouponRedemptionNotFoundException(Long targetId) {
         super(String.valueOf(targetId), ErrorCode.COUPON_REDEMPTION_NOT_FOUND);
+    }
+
+    public CouponRedemptionNotFoundException(UUID couponCode) {
+        super(couponCode.toString(), ErrorCode.COUPON_REDEMPTION_NOT_FOUND);
     }
 }

--- a/src/test/java/com/coumin/woowahancoupons/coupon/service/SimpleCouponRedemptionServiceTest.java
+++ b/src/test/java/com/coumin/woowahancoupons/coupon/service/SimpleCouponRedemptionServiceTest.java
@@ -271,6 +271,7 @@ class SimpleCouponRedemptionServiceTest {
         couponRedemptionService.useCustomerCoupon(couponRedemptionId);
 
         //Then
+        verify(couponRedemptionRepository, times(1)).findById(couponRedemptionId);
         verify(spyCouponRedemption, times(1)).use();
         SoftAssertions.assertSoftly(softAssertions -> {
                 softAssertions.assertThat(spyCouponRedemption.isUsed()).isEqualTo(true);
@@ -295,6 +296,7 @@ class SimpleCouponRedemptionServiceTest {
             .isInstanceOf(CouponRedemptionNotFoundException.class)
             .hasMessageContaining(ErrorCode.COUPON_REDEMPTION_NOT_FOUND.getMessage());
 
+        verify(couponRedemptionRepository, times(1)).findById(couponRedemptionId);
         verify(spyCouponRedemption, never()).use();
         SoftAssertions.assertSoftly(softAssertions -> {
                 softAssertions.assertThat(spyCouponRedemption.isUsed()).isEqualTo(false);
@@ -346,7 +348,7 @@ class SimpleCouponRedemptionServiceTest {
             .isInstanceOf(CouponRedemptionExpireException.class)
             .hasMessageContaining(ErrorCode.COUPON_REDEMPTION_EXPIRE.getMessage());
 
-        verify(couponRedemptionRepository, only()).findById(couponRedemptionId);
+        verify(couponRedemptionRepository, times(1)).findById(couponRedemptionId);
         verify(spyCouponRedemption, times(1)).use();
         SoftAssertions.assertSoftly(softAssertions -> {
                 softAssertions.assertThat(spyCouponRedemption.isUsed()).isEqualTo(false);

--- a/src/test/java/com/coumin/woowahancoupons/coupon/service/SimpleCouponRedemptionServiceTest.java
+++ b/src/test/java/com/coumin/woowahancoupons/coupon/service/SimpleCouponRedemptionServiceTest.java
@@ -268,13 +268,13 @@ class SimpleCouponRedemptionServiceTest {
         //Given
         try(MockedStatic<LocalDateTime> localDateTimeMockedStatic = mockStatic(LocalDateTime.class, CALLS_REAL_METHODS)) {
             Long couponRedemptionId = 1L;
-            LocalDateTime mockNow = LocalDateTime.of(2021, 11, 3, 17, 45, 30);
+            LocalDateTime expectedUsedTime = LocalDateTime.of(2021, 11, 3, 17, 45, 30);
             Coupon spyCoupon = spy(TestCouponFactory.builder().build());
             Customer mockCustomer = mock(Customer.class);
             CouponRedemption spyCouponRedemption = spy(
                 CouponRedemption.of(spyCoupon, mockCustomer));
 
-            localDateTimeMockedStatic.when(LocalDateTime::now).thenReturn(mockNow);
+            localDateTimeMockedStatic.when(LocalDateTime::now).thenReturn(expectedUsedTime);
             given(couponRedemptionRepository.findById(couponRedemptionId))
                 .willReturn(Optional.of(spyCouponRedemption));
 
@@ -287,7 +287,7 @@ class SimpleCouponRedemptionServiceTest {
             SoftAssertions.assertSoftly(softAssertions -> {
                     softAssertions.assertThat(spyCouponRedemption.isUsed()).isEqualTo(true);
                     softAssertions.assertThat(spyCouponRedemption.getUsedAt()).isAfter(LocalDateTime.of(2021, 11, 3, 17, 45, 29));
-                    softAssertions.assertThat(spyCouponRedemption.getUsedAt()).isEqualTo(mockNow);
+                    softAssertions.assertThat(spyCouponRedemption.getUsedAt()).isEqualTo(expectedUsedTime);
                     softAssertions.assertThat(spyCouponRedemption.getUsedAt()).isBefore(LocalDateTime.of(2021, 11, 3, 17, 45, 31));
                 }
             );

--- a/src/test/java/com/coumin/woowahancoupons/coupon/service/SimpleCouponRedemptionServiceTest.java
+++ b/src/test/java/com/coumin/woowahancoupons/coupon/service/SimpleCouponRedemptionServiceTest.java
@@ -5,9 +5,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.coumin.woowahancoupons.coupon.converter.CouponRedemptionConverter;
@@ -20,17 +23,21 @@ import com.coumin.woowahancoupons.domain.coupon.CouponRepository;
 import com.coumin.woowahancoupons.domain.customer.Customer;
 import com.coumin.woowahancoupons.domain.customer.CustomerRepository;
 import com.coumin.woowahancoupons.global.error.ErrorCode;
+import com.coumin.woowahancoupons.global.exception.CouponAlreadyUseException;
 import com.coumin.woowahancoupons.global.exception.CouponMaxCountOverException;
 import com.coumin.woowahancoupons.global.exception.CouponNotFoundException;
 import com.coumin.woowahancoupons.global.exception.CouponRedemptionAlreadyAllocateCustomer;
+import com.coumin.woowahancoupons.global.exception.CouponRedemptionExpireException;
 import com.coumin.woowahancoupons.global.exception.CouponRedemptionNotFoundException;
 import com.coumin.woowahancoupons.global.exception.CustomerNotFoundException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -109,18 +116,19 @@ class SimpleCouponRedemptionServiceTest {
         Coupon coupon = TestCouponFactory.builder().build();
         CouponRedemption couponRedemption = CouponRedemption.of(coupon);
 
-        given(couponRedemptionRepository.findByCouponCode(couponRedemption.getCouponCode()))
+        UUID couponCode = couponRedemption.getCouponCode();
+        given(couponRedemptionRepository.findByCouponCode(couponCode))
             .willReturn(Optional.of(couponRedemption));
         given(customerRepository.getById(customerId)).willReturn(mockCustomer);
 
         couponRedemptionService.allocateExistingCouponToCustomer(
-            couponRedemption.getCouponCode(),
+            couponCode,
             customerId
         );
 
         //When Then
         assertThatThrownBy(() -> couponRedemptionService.allocateExistingCouponToCustomer(
-            couponRedemption.getCouponCode(),
+            couponCode,
             customerId))
             .isInstanceOf(CouponRedemptionAlreadyAllocateCustomer.class)
             .hasMessageContaining(ErrorCode.COUPON_REDEMPTION_ALREADY_ALLOCATE.getMessage());
@@ -174,6 +182,7 @@ class SimpleCouponRedemptionServiceTest {
     void allocateCouponToCustomerWithIssuanceFailureTest2() {
         //Given
         Coupon spyCoupon = spy(TestCouponFactory.builder().build());
+        Long couponId = spyCoupon.getId();
         Long invalidCustomerId = 1L;
 
         given(couponRepository.findById(any())).willReturn(Optional.of(spyCoupon));
@@ -181,7 +190,7 @@ class SimpleCouponRedemptionServiceTest {
 
         //When Then
         assertThatThrownBy(() -> couponRedemptionService.allocateCouponToCustomerWithIssuance(
-            spyCoupon.getId(),
+            couponId,
             invalidCustomerId))
             .isInstanceOf(CustomerNotFoundException.class)
             .hasMessageContaining(ErrorCode.CUSTOMER_NOT_FOUND.getMessage());
@@ -245,5 +254,104 @@ class SimpleCouponRedemptionServiceTest {
         //When Then
         assertThatThrownBy(() -> couponRedemptionService.issueCouponCodes(couponId, issuanceCount))
             .isInstanceOf(CouponMaxCountOverException.class);
+    }
+
+    @Test
+    @DisplayName("사용자의 쿠폰 사용 - 성공 테스트")
+    void useCustomerCouponSuccessTest() {
+        //Given
+        Long couponRedemptionId = 1L;
+        Coupon spyCoupon = spy(TestCouponFactory.builder().build());
+        Customer mockCustomer = mock(Customer.class);
+        CouponRedemption spyCouponRedemption = spy(CouponRedemption.of(spyCoupon, mockCustomer));
+        given(couponRedemptionRepository.findById(couponRedemptionId))
+            .willReturn(Optional.of(spyCouponRedemption));
+
+        //When
+        couponRedemptionService.useCustomerCoupon(couponRedemptionId);
+
+        //Then
+        verify(spyCouponRedemption, times(1)).use();
+        SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(spyCouponRedemption.isUsed()).isEqualTo(true);
+                softAssertions.assertThat(spyCouponRedemption.getUsedAt()).isBefore(LocalDateTime.now());
+            }
+        );
+    }
+
+    @Test
+    @DisplayName("사용자의 쿠폰 사용 - 실패 테스트(존재하지 않는 쿠폰)")
+    void useCustomerCouponFailureTest() {
+        //Given
+        Long couponRedemptionId = 1L;
+        Coupon spyCoupon = spy(TestCouponFactory.builder().build());
+        Customer mockCustomer = mock(Customer.class);
+        CouponRedemption spyCouponRedemption = spy(CouponRedemption.of(spyCoupon, mockCustomer));
+        given(couponRedemptionRepository.findById(couponRedemptionId))
+            .willReturn(Optional.empty());
+
+        //When, Then
+        assertThatThrownBy(() -> couponRedemptionService.useCustomerCoupon(couponRedemptionId))
+            .isInstanceOf(CouponRedemptionNotFoundException.class)
+            .hasMessageContaining(ErrorCode.COUPON_REDEMPTION_NOT_FOUND.getMessage());
+
+        verify(spyCouponRedemption, never()).use();
+        SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(spyCouponRedemption.isUsed()).isEqualTo(false);
+                softAssertions.assertThat(spyCouponRedemption.getUsedAt()).isNull();
+            }
+        );
+    }
+
+    @Test
+    @DisplayName("사용자의 쿠폰 사용 - 실패 테스트(이미 사용한 쿠폰)")
+    void useCustomerCouponFailureTest2() {
+        //Given
+        Long couponRedemptionId = 1L;
+        Coupon spyCoupon = spy(TestCouponFactory.builder().build());
+        Customer mockCustomer = mock(Customer.class);
+        CouponRedemption spyCouponRedemption = spy(CouponRedemption.of(spyCoupon, mockCustomer));
+        given(couponRedemptionRepository.findById(couponRedemptionId))
+            .willReturn(Optional.of(spyCouponRedemption));
+        willThrow(new CouponAlreadyUseException()).given(spyCouponRedemption).use();
+
+        //When, Then
+        assertThatThrownBy(() -> couponRedemptionService.useCustomerCoupon(couponRedemptionId))
+            .isInstanceOf(CouponAlreadyUseException.class)
+            .hasMessageContaining(ErrorCode.COUPON_REDEMPTION_ALREADY_USE.getMessage());
+
+        verify(couponRedemptionRepository, times(1)).findById(couponRedemptionId);
+        verify(spyCouponRedemption, times(1)).use();
+        SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(spyCouponRedemption.isUsed()).isEqualTo(false);
+                softAssertions.assertThat(spyCouponRedemption.getUsedAt()).isNull();
+            }
+        );
+    }
+
+    @Test
+    @DisplayName("사용자의 쿠폰 사용 - 실패 테스트(사용 기한이 만료된 쿠폰)")
+    void useCustomerCouponFailureTest3() {
+        //Given
+        Long couponRedemptionId = 1L;
+        Coupon spyCoupon = spy(TestCouponFactory.builder().build());
+        Customer mockCustomer = mock(Customer.class);
+        CouponRedemption spyCouponRedemption = spy(CouponRedemption.of(spyCoupon, mockCustomer));
+        given(couponRedemptionRepository.findById(couponRedemptionId))
+            .willReturn(Optional.of(spyCouponRedemption));
+        willThrow(new CouponRedemptionExpireException()).given(spyCouponRedemption).use();
+
+        //When, Then
+        assertThatThrownBy(() -> couponRedemptionService.useCustomerCoupon(couponRedemptionId))
+            .isInstanceOf(CouponRedemptionExpireException.class)
+            .hasMessageContaining(ErrorCode.COUPON_REDEMPTION_EXPIRE.getMessage());
+
+        verify(couponRedemptionRepository, only()).findById(couponRedemptionId);
+        verify(spyCouponRedemption, times(1)).use();
+        SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(spyCouponRedemption.isUsed()).isEqualTo(false);
+                softAssertions.assertThat(spyCouponRedemption.getUsedAt()).isNull();
+            }
+        );
     }
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
[WOOCOU-74](https://maenguin.atlassian.net/browse/WOOCOU-74)

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 사용자의 쿠폰을 사용하는 서비스인 `useCustomerCoupon(Long couponRedemptionId)` 구현했습니다.
- CouponRedemption 엔티티의 verify 메서드 private로 잠궜습니다.
- CouponRedemption jpa repo UUID로 id 되어있던 부분 수정했습니다.
- CouponExpireException -> CouponRedemptionExpireException 네이밍 수정했습니다.
- 테스트 코드 추가했습니다.
- 이외에 lint 걸리는 부분 수정했습니다

이 서비스는 실제 쿠폰 사용과 관련된 서비스이고
쿠폰을 해당 order에서 사용할 수 있는지 확인하는 서비스는 제외입니다