### PR TITLE
[WOOCOU-79] ⭐ feat : 쿠폰 할인 타입에 따른 amount conditional validation 추가

### DIFF
--- a/src/main/java/com/coumin/woowahancoupons/coupon/controller/CouponRestController.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/controller/CouponRestController.java
@@ -6,12 +6,14 @@ import com.coumin.woowahancoupons.coupon.dto.StoreCouponSaveRequestDto;
 import com.coumin.woowahancoupons.coupon.service.CouponService;
 import com.coumin.woowahancoupons.global.ApiResponse;
 import javax.validation.Valid;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequestMapping("api/v1/coupons")
 public class CouponRestController {

--- a/src/main/java/com/coumin/woowahancoupons/coupon/controller/CouponRestController.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/controller/CouponRestController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Validated
 @RestController
 @RequestMapping("api/v1/coupons")
 public class CouponRestController {

--- a/src/main/java/com/coumin/woowahancoupons/coupon/dto/CouponCheckRequestDto.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/dto/CouponCheckRequestDto.java
@@ -1,6 +1,7 @@
 package com.coumin.woowahancoupons.coupon.dto;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +13,7 @@ public class CouponCheckRequestDto {
     @NotNull
     private Long storeId;
 
+    @PositiveOrZero
     @NotNull
     private Long orderPrice;
 

--- a/src/main/java/com/coumin/woowahancoupons/coupon/dto/CouponCreateRequestDto.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/dto/CouponCreateRequestDto.java
@@ -1,11 +1,13 @@
 package com.coumin.woowahancoupons.coupon.dto;
 
+import com.coumin.woowahancoupons.coupon.validator.annotation.CouponAmountConstraint;
+import com.coumin.woowahancoupons.coupon.validator.annotation.FixedAmountGroup;
+import com.coumin.woowahancoupons.coupon.validator.annotation.PercentAmountGroup;
 import java.time.LocalDateTime;
 import javax.validation.constraints.FutureOrPresent;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.PositiveOrZero;
 import javax.validation.constraints.Size;
@@ -13,15 +15,19 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@CouponAmountConstraint
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CouponCreateRequestDto {
 
     @Size(min = 1, max = 100)
-    @NotNull
+    @NotBlank
     private String name;
 
-    @Max(10_000)
+    @Max(value = 10_000, groups = FixedAmountGroup.class)
+    @Min(value = 1000, groups = FixedAmountGroup.class)
+    @Max(value = 100, groups = PercentAmountGroup.class)
+    @Min(value = 10, groups = PercentAmountGroup.class)
     private Long amount;
 
     @Max(100_000)

--- a/src/main/java/com/coumin/woowahancoupons/coupon/validator/CouponAmountConstraintValidator.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/validator/CouponAmountConstraintValidator.java
@@ -30,6 +30,7 @@ public class CouponAmountConstraintValidator implements
             constraintViolations
                 .forEach(constraintViolation -> context
                     .buildConstraintViolationWithTemplate(constraintViolation.getMessage())
+                    .addPropertyNode(constraintViolation.getPropertyPath().toString())
                     .addConstraintViolation());
             return false;
         }

--- a/src/main/java/com/coumin/woowahancoupons/coupon/validator/CouponAmountConstraintValidator.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/validator/CouponAmountConstraintValidator.java
@@ -1,0 +1,48 @@
+package com.coumin.woowahancoupons.coupon.validator;
+
+import com.coumin.woowahancoupons.coupon.dto.CouponCreateRequestDto;
+import com.coumin.woowahancoupons.coupon.validator.annotation.CouponAmountConstraint;
+import com.coumin.woowahancoupons.coupon.validator.annotation.FixedAmountGroup;
+import com.coumin.woowahancoupons.coupon.validator.annotation.PercentAmountGroup;
+import com.coumin.woowahancoupons.domain.coupon.DiscountType;
+import java.util.Collections;
+import java.util.Set;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+
+public class CouponAmountConstraintValidator implements
+    ConstraintValidator<CouponAmountConstraint, CouponCreateRequestDto> {
+
+    private final Validator validator;
+
+    public CouponAmountConstraintValidator(Validator validator) {
+        this.validator = validator;
+    }
+
+    @Override
+    public boolean isValid(CouponCreateRequestDto value, ConstraintValidatorContext context) {
+        final Set<ConstraintViolation<Object>> constraintViolations = getConstraintViolations(value);
+
+        if (!constraintViolations.isEmpty()) {
+            context.disableDefaultConstraintViolation();
+            constraintViolations
+                .forEach(constraintViolation -> context
+                    .buildConstraintViolationWithTemplate(constraintViolation.getMessage())
+                    .addConstraintViolation());
+            return false;
+        }
+        return true;
+    }
+
+    private  Set<ConstraintViolation<Object>> getConstraintViolations(CouponCreateRequestDto value) {
+        if (DiscountType.valueOf(value.getDiscountType()) == DiscountType.FIXED_AMOUNT) {
+            return validator.validate(value, FixedAmountGroup.class);
+        }
+        if (DiscountType.valueOf(value.getDiscountType()) == DiscountType.PERCENT_DISCOUNT) {
+            return validator.validate(value, PercentAmountGroup.class);
+        }
+        return Collections.emptySet();
+    }
+}

--- a/src/main/java/com/coumin/woowahancoupons/coupon/validator/annotation/CouponAmountConstraint.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/validator/annotation/CouponAmountConstraint.java
@@ -1,0 +1,24 @@
+package com.coumin.woowahancoupons.coupon.validator.annotation;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import com.coumin.woowahancoupons.coupon.validator.CouponAmountConstraintValidator;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+
+@Constraint(validatedBy = CouponAmountConstraintValidator.class)
+@Target({TYPE})
+@Retention(RUNTIME)
+@Documented
+public @interface CouponAmountConstraint {
+    String message() default "test";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/coumin/woowahancoupons/coupon/validator/annotation/CouponAmountConstraint.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/validator/annotation/CouponAmountConstraint.java
@@ -16,7 +16,7 @@ import javax.validation.Payload;
 @Retention(RUNTIME)
 @Documented
 public @interface CouponAmountConstraint {
-    String message() default "test";
+    String message() default "";
 
     Class<?>[] groups() default {};
 

--- a/src/main/java/com/coumin/woowahancoupons/coupon/validator/annotation/FixedAmountGroup.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/validator/annotation/FixedAmountGroup.java
@@ -1,5 +1,5 @@
 package com.coumin.woowahancoupons.coupon.validator.annotation;
 
-public @interface FixedAmountGroup {
+public interface FixedAmountGroup {
 
 }

--- a/src/main/java/com/coumin/woowahancoupons/coupon/validator/annotation/FixedAmountGroup.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/validator/annotation/FixedAmountGroup.java
@@ -1,0 +1,5 @@
+package com.coumin.woowahancoupons.coupon.validator.annotation;
+
+public @interface FixedAmountGroup {
+
+}

--- a/src/main/java/com/coumin/woowahancoupons/coupon/validator/annotation/PercentAmountGroup.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/validator/annotation/PercentAmountGroup.java
@@ -1,0 +1,5 @@
+package com.coumin.woowahancoupons.coupon.validator.annotation;
+
+public @interface PercentAmountGroup {
+
+}

--- a/src/main/java/com/coumin/woowahancoupons/coupon/validator/annotation/PercentAmountGroup.java
+++ b/src/main/java/com/coumin/woowahancoupons/coupon/validator/annotation/PercentAmountGroup.java
@@ -1,5 +1,5 @@
 package com.coumin.woowahancoupons.coupon.validator.annotation;
 
-public @interface PercentAmountGroup {
+public interface PercentAmountGroup {
 
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
[WOOCOU-79](https://maenguin.atlassian.net/browse/WOOCOU-79)

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
쿠폰의 할인 타입 조건에 따른(고정 금액 vs 퍼센티지) 커스텀 validator를 추가해서 조건별로 동작하도록 했습니다.  
- [참고](https://meetup.toast.com/posts/223)
- `@CouponAmountConstraint` : 쿠폰 할인 금액 제약 애노테이션
- `FixedAmountGroup` :  고정 할인 금액 그룹을 지정하기 위한 마커 인터페이스
- `PercentAmountGroup` : 퍼센티지 할인 금액 그룹을 지정하기 위한 마커 인터페이스